### PR TITLE
chore: update Prettier integration and refine esbuild configuration

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,3 +4,4 @@
 !LICENSE
 !public/**
 !dist/**
+!node_modules/prettier/**

--- a/scripts/esbuild.js
+++ b/scripts/esbuild.js
@@ -59,7 +59,8 @@ async function bundleExtension() {
       format: 'cjs',
       sourcemap: false,
       minify: true,
-      external: ['vscode', 'prettier', ...optionalTemplateEngines],
+      // 打包内置依赖（含 prettier/standalone 与其插件），仅将 vscode 与可选模板引擎外置
+      external: ['vscode', ...optionalTemplateEngines],
       logLevel: 'info',
     });
     console.log('✅ esbuild 打包完成: dist/extension.js');


### PR DESCRIPTION
- Switched to using Prettier Standalone with specific parsers to avoid issues in VSIX environments.
- Updated esbuild configuration to exclude Prettier from external dependencies, ensuring it is bundled correctly.
- Simplified Prettier configuration to use built-in rules, improving performance and reliability.