### PR TITLE
chore: update VS Code extension publishing process and add prepublish…

### DIFF
--- a/.github/workflows/auto-deploy-to-vscode-marketplace.yaml
+++ b/.github/workflows/auto-deploy-to-vscode-marketplace.yaml
@@ -46,7 +46,7 @@ jobs:
         run: test -f dist/extension.js
 
       - name: Publish VS Code Extension (vsce)
-        run: vsce publish --no-dependencies -p ${{ secrets.VS_MARKETPLACE_TOKEN }}
+        run: vsce publish --yarn -p ${{ secrets.VS_MARKETPLACE_TOKEN }}
 
       - name: Push changes
         run: |
@@ -89,7 +89,7 @@ jobs:
       - name: Package extension
         run: |
           test -f dist/extension.js || (echo "dist/extension.js missing" && exit 1)
-          vsce package --no-dependencies
+          vsce package --yarn
 
       - name: Get package info
         id: package

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "lint": "eslint --fix .",
     "test": "vscode-test",
     "build": "node scripts/esbuild.js",
+    "vscode:prepublish": "npm run build",
     "test:unit": "node tests/run-tests.js",
     "test:i18n": "node tests/unit/demoTest.validation.js",
     "test:js": "node tests/unit/jsProcessor.test.js",


### PR DESCRIPTION
… script

- Added a new script `vscode:prepublish` to streamline the build process before publishing.
- Updated the GitHub Actions workflow to use Yarn for publishing and packaging the VS Code extension, enhancing dependency management.