### PR TITLE
fix: update i18nFilePath to use absolute path in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ tsx对比图：<https://www.diffchecker.com/OaZLu99x/>
 
 |属性|描述|默认值|
 |:--|:--|:--|
-|i18nFilePath|指定国际化文件的根目录。| 'src/i18n' |
+|i18nFilePath|指定国际化文件的根目录。| '/src/i18n' |
 |autoImportI18n|是否自动导入i18n模块。| true |
 |i18nImportPath|自动导入i18n模块的路径。| '@/i18n' |
 |templateI18nCall|在 Vue 模板中调用翻译函数的语法。| '$t' |

--- a/src/script/setting.js
+++ b/src/script/setting.js
@@ -5,7 +5,7 @@ const { getRootPath } = require('../utils');
 
 const defaultConfig = {
   // 使用相对工程根的路径，避免在 Windows 把以 / 开头识别为绝对根
-  i18nFilePath: 'src/i18n',
+  i18nFilePath: '/src/i18n',
   autoImportI18n: true,
   i18nImportPath: '@/i18n',
   templateI18nCall: '$t',


### PR DESCRIPTION
- Changed the `i18nFilePath` in both README.md and setting.js from a relative path to an absolute path, ensuring consistent behavior across different environments.